### PR TITLE
install libraries in /usr/lib

### DIFF
--- a/owncloud-client/PKGBUILD
+++ b/owncloud-client/PKGBUILD
@@ -43,7 +43,7 @@ build() {
   mkdir ${srcdir}/${_name}-${pkgver}-build
   cd ${srcdir}/${_name}-${pkgver}-build
 
-  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${_buildtype} ../${_name}-${pkgver}
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib -DCMAKE_BUILD_TYPE=${_buildtype} ../${_name}-${pkgver}
   make
 }
 


### PR DESCRIPTION
fix for "error while loading shared libraries: libowncloudsync.so: cannot open shared object file: No such file or directory" on 64bit systems
see comments on https://aur.archlinux.org/packages.php?ID=58177
