### PR TITLE
tomahawk: update jreen>=1.1.1 dependency

### DIFF
--- a/tomahawk/PKGBUILD
+++ b/tomahawk/PKGBUILD
@@ -20,7 +20,7 @@ pkgdesc="A Music Player App written in C++/Qt"
 arch=('i686' 'x86_64')
 url="http://tomahawk-player.org/"
 license=('GPL3')
-depends=('phonon' 'taglib' 'boost' 'clucene' 'libechonest2' 'jreen' 'qtweetlib' 'quazip' 'attica' 'qtwebkit' 'liblastfm1')
+depends=('phonon' 'taglib' 'boost' 'clucene' 'libechonest2' 'jreen>=1.1.1' 'qtweetlib' 'quazip' 'attica' 'qtwebkit' 'liblastfm1')
 makedepends=('cmake')
 optdepends=('tomahawk-spotify-git: spotify resolver')
 provides=('tomahawk')


### PR DESCRIPTION
```
-- Found Jreen: /usr/lib/libjreen.so (Required is at least version "1.0.5") 
CMake Error at CMakeLists.txt:140 (message):
  Jreen 1.1.0 has a very annoying bug that breaks accepting auth requests in
  Tomahawk.  Please upgrade to 1.1.1 or downgrade to 1.0.5.
```
