### PR TITLE
cfengine: using /var/cfengine instead of /var/lib/cfengine (and other changes)

### DIFF
--- a/cfengine/PKGBUILD
+++ b/cfengine/PKGBUILD
@@ -13,32 +13,32 @@ license=('GPL3')
 arch=('i686' 'x86_64')
 depends=('qdbm' 'openssl' 'pcre' 'libxml2')
 makedepends=('which')
-optdepends=('tokyocabinet' 'libvirt' 'postgresql-libs' 'libmariadbclient')
+optdepends=('tokyocabinet' 'libvirt' 'postgresql-libs' 'libmariadbclient' 'acl')
 install=${pkgname}.install
 source=("${pkgname}-${pkgver}.tar.gz::http://cfengine.com/source-code/download?file=${pkgname}-${pkgver}.tar.gz"
         'cf-execd.service'
         'cf-monitord.service'
         'cf-serverd.service')
 md5sums=('c840eb0163924ca657ab180fe5a170b4'
-         'bf64e1dedbcef5a74e3b585076135c87'
-         'c56bde562ec29c1533433a320f4f4b5d'
-         '2a3aed38b03b14335a70103e45d42ee8')
+         'dba17dc5133b8fa86de11577120d46c5'
+         'a2f9db31408f288cb934397ffb474db3'
+         'ff28f7de9b81b4673082a2640a318896')
 
 build() {
 	cd ${srcdir}/${pkgname}-${pkgver}
 
   ./configure \
     --prefix=/usr \
-    --with-workdir=/var/lib/${pkgname} \
+    --with-workdir=/var/${pkgname} \
     --with-openssl \
     --with-pcre \
     --with-libacl=check \
     --with-libxml2 \
-    --without-libvirt \
+    --with-libvirt=check \
     --with-qdbm \
-    --without-mysql \
-    --without-tokyocabinet \
-    --without-postgresql
+    --with-mysql=check \
+    --with-tokyocabinet=check \
+    --with-postgresql=check
 
   make
 }
@@ -57,4 +57,3 @@ package() {
 }
 
 # vim:set ts=2 sw=2 et:
-

--- a/cfengine/cf-execd.service
+++ b/cfengine/cf-execd.service
@@ -3,9 +3,9 @@ Description=CFEngine Execution Daemon
 After=syslog.target
 
 [Service]
-ExecStart=/usr/bin/cf-execd
+ExecStart=/var/cfengine/bin/cf-execd
 Type=forking
-PIDFile=/srv/cfengine/cf-execd.pid
+PIDFile=/var/cfengine/cf-execd.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/cfengine/cf-monitord.service
+++ b/cfengine/cf-monitord.service
@@ -3,9 +3,9 @@ Description=CFEngine Monitoring Daemon
 After=syslog.target
 
 [Service]
-ExecStart=/usr/bin/cf-monitord
+ExecStart=/var/cfengine/bin/cf-monitord
 Type=forking
-PIDFile=/srv/cfengine/cf-monitord.pid
+PIDFile=/var/cfengine/cf-monitord.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/cfengine/cf-serverd.service
+++ b/cfengine/cf-serverd.service
@@ -3,9 +3,9 @@ Description=CFEngine Server Daemon
 After=syslog.target
 
 [Service]
-ExecStart=/usr/bin/cf-serverd
+ExecStart=/var/cfengine/bin/cf-serverd
 Type=forking
-PIDFile=/srv/cfengine/cf-serverd.pid
+PIDFile=/var/cfengine/cf-serverd.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/cfengine/cfengine.install
+++ b/cfengine/cfengine.install
@@ -1,11 +1,24 @@
 post_install() {
 
- if [ ! -f /var/lib/cfengine/ppkeys/localhost.priv ]; then
+ if [ ! -f /var/cfengine/ppkeys/localhost.priv ]; then
   cf-key > /dev/null
  fi 
 
- if ! [ -f /var/lib/cfengine/masterfiles/promises.cf ]; then
-  cp -R /usr/share/CoreBase/* /var/lib/cfengine/masterfiles/
+ if ! [ -f /var/cfengine/masterfiles/promises.cf ]; then
+  cp -R /usr/share/CoreBase/* /var/cfengine/masterfiles/
+ fi
+ 
+ if ! [ -f /var/cfengine/bin/cf-promises ]; then
+  cd /var/cfengine/bin
+  ln -s /usr/bin/cf-* .
  fi
 
+ echo "Bootstrap cfengine with cf-agent --bootstrap <IP address of policy server>"
+
+}
+post_remove() {
+
+ if [ -d /var/cfengine/bin ]; then
+   rm /var/cfengine/bin/*
+ fi
 }


### PR DESCRIPTION
- using /var/cfengine instead of /var/lib/cfengine 
- creating symlins in /var/cfengine/bin
- auto-detecting optional dependencies during build
- adding 'acl' to list of optional dependencies
  with those modifications I was able to run "cf-agent --bootstrap <policy-server>" immediately after install, and client happily joined our CFEngine controller network (cfengine master is running on Debian server).
